### PR TITLE
Bump Python dependency up to 3.6+ so it's compatible w/ latest Molotov 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-slim
+FROM python:3.6-slim
 
 RUN apt-get update && \
     apt-get install -y git && \


### PR DESCRIPTION
Fixes #3 

Once this lands, I presume we'll need @tarekziade to push a new version to https://hub.docker.com/r/tarekziade/molotov to unblock the Docker examples in https://github.com/mozilla-services/syncstorage-loadtest and https://github.com/loads/molotov-docker README files.
